### PR TITLE
Bump for dev security patch and jest-expect-message.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "jest": "27.3.1",
-        "jest-expect-message": "1.0.2"
+        "jest-expect-message": "1.1.2"
       },
       "engines": {
         "node": ">12.0.0",
@@ -1329,14 +1329,20 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001282",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
-      "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==",
+      "version": "1.0.30001397",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001397.tgz",
+      "integrity": "sha512-SW9N2TbCdLf0eiNDRrrQXx2sOkaakNZbCjgNpPyMJJbiOrU5QzMIrXOVMRM1myBXTD5iTkdrtU/EguCrBocHlA==",
       "dev": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ]
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2391,9 +2397,9 @@
       }
     },
     "node_modules/jest-expect-message": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.0.2.tgz",
-      "integrity": "sha512-WFiXMgwS2lOqQZt1iJMI/hOXpUm32X+ApsuzYcQpW5m16Pv6/Gd9kgC+Q+Q1YVNU04kYcAOv9NXMnjg6kKUy6Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.1.2.tgz",
+      "integrity": "sha512-0rGSMkJdc3uupzkPxtkZKBKY1Cb4VD4VxJP5sTRfFpVRe6fT7C9ItGwEeitJXIVzp4rKGgwkUFo1/+iQ02fZZA==",
       "dev": true
     },
     "node_modules/jest-get-type": {
@@ -3047,9 +3053,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/ms": {
@@ -5011,9 +5017,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001282",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001282.tgz",
-      "integrity": "sha512-YhF/hG6nqBEllymSIjLtR2iWDDnChvhnVJqp+vloyt2tEHFG1yBR+ac2B/rOw0qOK0m0lEXU2dv4E/sMk5P9Kg==",
+      "version": "1.0.30001397",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001397.tgz",
+      "integrity": "sha512-SW9N2TbCdLf0eiNDRrrQXx2sOkaakNZbCjgNpPyMJJbiOrU5QzMIrXOVMRM1myBXTD5iTkdrtU/EguCrBocHlA==",
       "dev": true
     },
     "chalk": {
@@ -5806,9 +5812,9 @@
       }
     },
     "jest-expect-message": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.0.2.tgz",
-      "integrity": "sha512-WFiXMgwS2lOqQZt1iJMI/hOXpUm32X+ApsuzYcQpW5m16Pv6/Gd9kgC+Q+Q1YVNU04kYcAOv9NXMnjg6kKUy6Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/jest-expect-message/-/jest-expect-message-1.1.2.tgz",
+      "integrity": "sha512-0rGSMkJdc3uupzkPxtkZKBKY1Cb4VD4VxJP5sTRfFpVRe6fT7C9ItGwEeitJXIVzp4rKGgwkUFo1/+iQ02fZZA==",
       "dev": true
     },
     "jest-get-type": {
@@ -6322,9 +6328,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "An API-oriented framework for composing units of work into readable, maintainable, and testable processes.",
   "main": "./dist/index.js",
   "scripts": {
-    "test": "jest --config=jest.config.js --watch",
+    "test": "jest",
+    "test:watch": "jest --watch",
     "pub": "git push --tags && npm publish"
   },
   "repository": {
@@ -23,7 +24,6 @@
   },
   "devDependencies": {
     "jest": "27.3.1",
-    "jest-expect-message": "1.0.2"
-  },
-  "dependencies": {}
+    "jest-expect-message": "1.1.2"
+  }
 }

--- a/test/errorLogging.spec.js
+++ b/test/errorLogging.spec.js
@@ -10,13 +10,13 @@ describe('Error Logging', () => {
     const getStartingContext = () => clone(startingContext);
 
     const expectProcessError = (logFunc) => {
-        expect(logFunc).toHaveBeenLastCalledWith(expect.stringContaining('ProcessError'));
+        expect(logFunc).toHaveBeenLastCalledWith(expect.any(ProcessError));
     }
 
     const expectStartingContext = (logFunc, beforeArgs = [], afterArgs = []) => {
         const allArgs = [
             ...beforeArgs,
-            expect.stringMatching(/startingContext:[\s\S]+myId:.+382828/),
+            expect.objectContaining({ startingContext }),
             ...afterArgs,
         ]
         expect(logFunc).toHaveBeenCalledWith(...allArgs);

--- a/test/logging.spec.js
+++ b/test/logging.spec.js
@@ -45,7 +45,7 @@ describe('Logging', () => {
         const testObj = { foo: 'bar' };
         const testString = 'my string';
 
-        const expected = [testNum, require('util').inspect(testObj, false, 10), testString]; // see above note on jest mucking with console func params
+        const expected = [testNum, testObj, testString];
 
         logging.debug(testNum, testObj, testString);
 

--- a/test/prerequisites.spec.js
+++ b/test/prerequisites.spec.js
@@ -80,11 +80,14 @@ describe('Prerequisites', () => {
         disableErrorLogging();
 
         const processErrMessage = `Process '${procName}' has invalid configuration. See logs for details.`;
+        const { InvalidProcessError } = require('../src/errors')
         const logVerifier = jest.fn((msg, exDetails) => {
             expect(msg.indexOf(procName)).toBeGreaterThan(0);
-            expect(exDetails.indexOf(`InvalidProcessError: ${processErrMessage}`)).toEqual(0);
-            expect(exDetails.indexOf('at start'), 'logs stack trace').toBeGreaterThan(0);
-            expect(exDetails.indexOf('configurationErrors:'), 'logs configurationErrors').toBeGreaterThan(0);
+            expect(exDetails).toBeInstanceOf(InvalidProcessError);
+            // verify config errors are logged:
+            expect(exDetails).toEqual(expect.objectContaining({
+                details: { configurationErrors: expect.any(Array)},
+            }));
         });
         logEmitter.on('error', logVerifier); // pass our own func to be called when error is logged
 


### PR DESCRIPTION
Update deps to address security flaw. Also update to use latest jest-expect-message--it now properly supports Jest 27+. 

Fix some error assertions. It seems I must have tweaked the logs to log objects as-is instead of strings, but overlooked fixing these when I did that. Doh. 